### PR TITLE
Revert "If the labels animation ends prematurely, reset it."

### DIFF
--- a/Pod/Classes/MRGMarqueeLabel.m
+++ b/Pod/Classes/MRGMarqueeLabel.m
@@ -258,7 +258,6 @@
         scrollAnimGroup.beginTime = CACurrentMediaTime() + self.pause;
         scrollAnimGroup.duration = duration + self.pause;
         scrollAnimGroup.repeatCount = INFINITY;
-        scrollAnimGroup.delegate = self;
         scrollAnimGroup.animations = @[scrollAnim];
         
         [self.labelsContainerView.layer addAnimation:scrollAnimGroup forKey:@"marquee"];
@@ -282,12 +281,6 @@
         maskAnimGroup.animations = @[maskColors];
         
         [self.maskLayer addAnimation:maskAnimGroup forKey:@"mask"];
-    }
-}
-
-- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
-    if (!flag) {
-        [self setNeedsAnimationReset];
     }
 }
 

--- a/Pod/Classes/MRGMarqueeLabel.m
+++ b/Pod/Classes/MRGMarqueeLabel.m
@@ -28,11 +28,7 @@
 
 #import "MRGMarqueeLabel.h"
 
-#ifdef __IPHONE_10_0
-@interface MRGMarqueeLabel () <CAAnimationDelegate>
-#else
 @interface MRGMarqueeLabel ()
-#endif
 
 @property (nonatomic, readonly) UIView *contentView;
 @property (nonatomic, readonly) UIView *labelsContainerView;


### PR DESCRIPTION
Reverts mirego/MRGMarqueeLabel#4

This caused the MarqueeLabel to trigger an infinite alternation of `animationDidStart` and `animationDidStop` after an orientation change. The label's animation is then broken for the rest of its lifetime.

What did the original change fixed exactly? Is it okay to revert it?