### PR TITLE
Remove animation when speed <= 0

### DIFF
--- a/Pod/Classes/MRGMarqueeLabel.m
+++ b/Pod/Classes/MRGMarqueeLabel.m
@@ -245,6 +245,8 @@
 
 - (void)handleAnimations {
     if (self.animationSpeed <= 0.f) {
+        [self.labelsContainerView.layer removeAnimationForKey:@"marquee"];
+        [self.maskLayer removeAnimationForKey:@"mask"];
         return;
     }
     


### PR DESCRIPTION
The mask animation continue when de speed for text scroll animation is set to 0 and make some glitch effect.

This PR modify the handleAnimations function to remove the mask and marquee animation if the speed <= 0